### PR TITLE
Add flow ID support to WSClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # play-micro-tools
 
-Mciro collection of tools simplifying the common tasks of writing micro-services in play.
+Micro collection of tools simplifying the common tasks of writing micro-services in play.
 

--- a/src/main/scala/microtools/ws/WSClientWithFlow.scala
+++ b/src/main/scala/microtools/ws/WSClientWithFlow.scala
@@ -1,0 +1,19 @@
+package microtools.ws
+
+import microtools.models.{AuthRequestContext, ExtraHeaders, RequestContext}
+import play.api.http.HeaderNames
+import play.api.libs.ws.{WSClient, WSRequest}
+
+class WSClientWithFlow(val underlying: WSClient) {
+
+  def url(rawUrl: String)(implicit ctx: RequestContext): WSRequest = {
+    underlying
+      .url(rawUrl)
+      .withHeaders(ExtraHeaders.FLOW_ID_HEADER -> ctx.flowId)
+  }
+
+  def urlWithAuthFromContext(rawUrl: String)(implicit ctx: AuthRequestContext): WSRequest = {
+    url(rawUrl)
+      .withHeaders(HeaderNames.AUTHORIZATION -> s"Bearer ${ctx.token}")
+  }
+}


### PR DESCRIPTION
Currently every caller of WSClient must remember to set the flow ID and/or authorization headers.
Wiring this wrapper instead of a raw WSClient into the DAOs will ensure that there is always a flow ID passed to WS calls.