### PR TITLE
[refactor] force users to use wsclient flow ID support

### DIFF
--- a/src/main/scala/microtools/wire/WithWSClient.scala
+++ b/src/main/scala/microtools/wire/WithWSClient.scala
@@ -1,7 +1,7 @@
 package microtools.wire
 
-import play.api.libs.ws.WSClient
+import microtools.ws.WSClientWithFlow
 
 trait WithWSClient {
-  def wsClient: WSClient
+  def wsClient: WSClientWithFlow
 }


### PR DESCRIPTION
The WithWSClient trait is used to declare a macwire dependency on the
wsclient, but there is really no reason to be using a raw WSClient
anymore. We should always be using the WSClientWithFlow now.
This is going to be a breaking change for all consumers because they
have to instantiate a WSClientWithFlow somewhere now and need at least
a request context in all code paths that result in an HTTP call.