### PR TITLE
TRADE-1668 [fix] replace and add patches

### DIFF
--- a/src/test/scala/microtools/BusinessTrySpec.scala
+++ b/src/test/scala/microtools/BusinessTrySpec.scala
@@ -64,13 +64,13 @@ class BusinessTrySpec extends WordSpec with MockFactory with MustMatchers with S
     }
 
     "be lifted from success try" in {
-      val successTry = Try("gegenbauer")
+      val successTry               = Try("gegenbauer")
       val BusinessSuccess(success) = BusinessTry.fromTry(successTry)(_ => Problems.BAD_REQUEST)
       success mustEqual "gegenbauer"
     }
 
     "be lifted from failure try" in {
-      val failureTry = Failure(new RuntimeException("Who you gonna call? Bauerbusters!"))
+      val failureTry               = Failure(new RuntimeException("Who you gonna call? Bauerbusters!"))
       val BusinessFailure(problem) = BusinessTry.fromTry(failureTry)(_ => Problems.BAD_REQUEST)
       problem mustEqual Problems.BAD_REQUEST
     }


### PR DESCRIPTION
Contrary to the RFC delete and replace don't fail if the target does
not exist. This seems to be the intuitive way to do things.